### PR TITLE
Enforce provided order price has no more than 8 decimal places

### DIFF
--- a/examples/create_order.py
+++ b/examples/create_order.py
@@ -16,10 +16,10 @@ async def main():
     )
 
     order_input = CreateOrderInput(
-        price="2000",
-        size="10",
+        price="0.86500000",
+        size="40",
         symbol="MATIC-USDC",
-        side="buy",
+        side="sell",
         clientOrderId="550e8400-e29b-41d4-a716-446655440000",
     )
 

--- a/orbs_orderbook/exceptions.py
+++ b/orbs_orderbook/exceptions.py
@@ -16,3 +16,7 @@ class ErrInvalidToken(Error):
 
 class ErrInvalidSide(Error):
     """Raised when the provided side is invalid."""
+
+
+class ErrDecimalPlaces(Error):
+    """Raised when the provided value has too many decimal places."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orbs-orderbook-sdk"
-version = "0.3.1"
+version = "0.4.0"
 description = "Python SDK for the Orbs order book"
 authors = ["Luke Rogerson <contact@lukerogerson.me>"]
 readme = "README.md"

--- a/tests/test_order_signer.py
+++ b/tests/test_order_signer.py
@@ -2,16 +2,33 @@ import pytest
 
 from orbs_orderbook import OrderSigner
 
+from orbs_orderbook.exceptions import ErrDecimalPlaces
+
+from decimal import Decimal
+
 
 @pytest.mark.parametrize(
     "size, price, side, decimals, expected",
     [
-        ("40", "0.87", "sell", 6, 34800000),
-        ("123734734873497834", 1, "sell", 6, 123734734873497834000000),
-        ("543", "0.09", "sell", 6, 48870000),
-        ("40", "0.87", "buy", 6, 40000000),
-        ("123734734873497834", 1, "buy", 6, 123734734873497834000000),
-        ("543", "0.09", "buy", 6, 543000000),
+        (Decimal("40"), Decimal("0.87"), "sell", 6, 34800000),
+        (
+            Decimal("123734734873497834"),
+            Decimal("1"),
+            "sell",
+            6,
+            123734734873497834000000,
+        ),
+        (Decimal("543"), Decimal("0.09"), "sell", 6, 48870000),
+        (Decimal("50"), Decimal("0.86440911"), "sell", 6, 43220455),
+        (Decimal("40"), Decimal("0.87"), "buy", 6, 40000000),
+        (
+            Decimal("123734734873497834"),
+            Decimal("1"),
+            "buy",
+            6,
+            123734734873497834000000,
+        ),
+        (Decimal("543"), Decimal("0.09"), "buy", 6, 543000000),
     ],
 )
 def test_calculate_out_amount(mocker, size, price, side, decimals, expected):
@@ -31,12 +48,25 @@ def test_calculate_out_amount(mocker, size, price, side, decimals, expected):
 @pytest.mark.parametrize(
     "size, price, side, decimals, expected",
     [
-        ("40", "0.87", "buy", 6, 34800000),
-        ("123734734873497834", 1, "buy", 6, 123734734873497834000000),
-        ("543", "0.09", "buy", 6, 48870000),
-        ("40", "0.87", "sell", 6, 40000000),
-        ("123734734873497834", 1, "sell", 6, 123734734873497834000000),
-        ("543", "0.09", "sell", 6, 543000000),
+        (Decimal("40"), Decimal("0.87"), "buy", 6, 34800000),
+        (
+            Decimal("123734734873497834"),
+            Decimal("1"),
+            "buy",
+            6,
+            123734734873497834000000,
+        ),
+        (Decimal("543"), Decimal("0.09"), "buy", 6, 48870000),
+        (Decimal("50"), Decimal("0.86440911"), "buy", 6, 43220455),
+        (Decimal("40"), Decimal("0.87"), "sell", 6, 40000000),
+        (
+            Decimal("123734734873497834"),
+            Decimal("1"),
+            "sell",
+            6,
+            123734734873497834000000,
+        ),
+        (Decimal("543"), Decimal("0.09"), "sell", 6, 543000000),
     ],
 )
 def test_calculate_in_amount(mocker, size, price, side, decimals, expected):
@@ -51,3 +81,37 @@ def test_calculate_in_amount(mocker, size, price, side, decimals, expected):
     )
 
     assert in_amount == expected, "Incorrect out amount"
+
+
+@pytest.mark.parametrize(
+    "price, should_raise",
+    [
+        (Decimal("0.86"), False),
+        (Decimal("22.23"), False),
+        (Decimal("1.862"), False),
+        (Decimal("0.000003"), False),
+        (Decimal("10002.000003"), False),
+        (Decimal("0"), False),
+        (Decimal("100"), False),
+        (Decimal("1.2345678"), False),
+        (Decimal("12345678901234567890.12345678"), False),
+        (Decimal("0.123456789"), True),
+        (Decimal("0.123456789123456789"), True),
+        (Decimal("1.000000001"), True),
+    ],
+)
+def test_check_decimal_places(mocker, price, should_raise):
+    client = mocker.Mock()
+    signer = OrderSigner(
+        private_key="0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        sdk=client,
+    )
+
+    if should_raise:
+        with pytest.raises(ErrDecimalPlaces) as e:
+            signer._check_decimal_places(price=price)
+    else:
+        try:
+            signer._check_decimal_places(price=price)
+        except ErrDecimalPlaces:
+            pytest.fail("Unexpected ErrDecimalPlaces raised")


### PR DESCRIPTION
Order book supports a maximum of 8 decimal places for prices. Add client check to enforce this.